### PR TITLE
fix the path under .vmodules

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,11 @@ You can omit `vpm.txt`, no packages will be installed then.
 
 Find available VPM modules in the [VPM modules directory](https://vlang.io/modules).
 
-`remote.txt` is a list of remote git repo urls and their module name that will be installed using `git clone remote_url ~/.vmodules/module_name` before your app is compiled. List one repo and module name per line separated by a space and *terminate with a new line*:
+`remote.txt` is a list of remote git repo urls and their module name that will be installed using `git clone remote_url ~/repo_author_name/module_name` and `ln -s ~/repo_author_name ~/.vmodules/` before your app is compiled. List one repo and module name per line separated by a space and *terminate with a new line*:
 
 ```
-https://www.github.com/username/repo_name.git module_name
-https://some_other_url/username/another_repo.git module_name_too
+https://www.github.com/username/repo_name.git repo_author_name module_name
+https://some_other_url/username/another_repo.git repo_author_name module_name_too
 ```
 
 creates the following directories:

--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ https://some_other_url/username/another_repo.git repo_author_name module_name_to
 
 creates the following directories:
 ```
-~/.vmodules/module_name
-~/.vmodules/module_name_too
+~/.vmodules/repo_author_name/module_name
+~/.vmodules/repo_author_name/module_name_too
 ```
 
 You can omit `remote.txt`, no repos will be cloned then.

--- a/bin/compile
+++ b/bin/compile
@@ -36,8 +36,8 @@ make
 PKGLIST=$BUILD_DIR/vpm.txt
 if [ -f "$PKGLIST" ]; then
     echo "Found vpm.txt, installing VPM packages" | arrow
+    echo "test"
     while read p; do
-      echo "test" | arrow
       echo "Installing $p" | indent | arrow
       $V_DIR/v install $p
     done < $PKGLIST
@@ -50,7 +50,8 @@ if [ -f "$REMOTELIST" ]; then
     echo "Found remote.txt, cloning remote git repo to ~/.vmodules" | arrow
     while read -ra arr; do
       echo "Cloning ${arr[0]} into ${arr[1]}" | indent | arrow
-      git clone ${arr[0]} ~/.vmodules/${arr[1]}
+      git clone ${arr[0]} ~/${arr[1]}
+      ln -s ~/${arr[1] ~/.vmodules
     done < $REMOTELIST
 else
     echo "remote.txt not found - do not install any thirdparty module from a remote repo." | arrow

--- a/bin/compile
+++ b/bin/compile
@@ -49,9 +49,10 @@ REMOTELIST=$BUILD_DIR/remote.txt
 if [ -f "$REMOTELIST" ]; then
     echo "Found remote.txt, cloning remote git repo to ~/.vmodules" | arrow
     while read -ra arr; do
-      echo "Cloning ${arr[0]} into ${arr[1]}" | indent | arrow
-      git clone ${arr[0]} ~/${arr[1]}
-      ln -s ~/${arr[1] ~/.vmodules
+      echo "Cloning ${arr[0]} into ${arr[1]}/${arr[2]}" | indent | arrow
+      git clone ${arr[0]} ~/${arr[2]}
+      mkdir ~/.vmodules/${arr[1]}
+      ln -s ~/${arr[2] ~/.vmodules/${arr[1]}
     done < $REMOTELIST
 else
     echo "remote.txt not found - do not install any thirdparty module from a remote repo." | arrow

--- a/bin/compile
+++ b/bin/compile
@@ -36,7 +36,6 @@ make
 PKGLIST=$BUILD_DIR/vpm.txt
 if [ -f "$PKGLIST" ]; then
     echo "Found vpm.txt, installing VPM packages" | arrow
-    echo "test"
     while read p; do
       echo "Installing $p" | indent | arrow
       $V_DIR/v install $p

--- a/bin/compile
+++ b/bin/compile
@@ -33,6 +33,8 @@ cd $V_DIR
 echo "Building V..." | arrow
 make
 
+./v symlink
+
 PKGLIST=$BUILD_DIR/vpm.txt
 if [ -f "$PKGLIST" ]; then
     echo "Found vpm.txt, installing VPM packages" | arrow

--- a/bin/compile
+++ b/bin/compile
@@ -59,6 +59,6 @@ else
 fi
 
 cd $BUILD_DIR
-$V_DIR/v -prod app.v
+$V_DIR/v app.v
 
 echo "using ${v_repo} @${v_branch}" | indent

--- a/bin/compile
+++ b/bin/compile
@@ -33,8 +33,6 @@ cd $V_DIR
 echo "Building V..." | arrow
 make
 
-./v symlink
-
 PKGLIST=$BUILD_DIR/vpm.txt
 if [ -f "$PKGLIST" ]; then
     echo "Found vpm.txt, installing VPM packages" | arrow

--- a/bin/compile
+++ b/bin/compile
@@ -51,6 +51,7 @@ if [ -f "$REMOTELIST" ]; then
     while read -ra arr; do
       echo "Cloning ${arr[0]} into ${arr[1]}/${arr[2]}" | indent | arrow
       git clone ${arr[0]} ~/${arr[1]}/${arr[2]}
+      echo "Symlink ~/${arr[1]} ~/.vmodules/"
       ln -s ~/${arr[1]} ~/.vmodules/
     done < $REMOTELIST
 else

--- a/bin/compile
+++ b/bin/compile
@@ -49,7 +49,7 @@ REMOTELIST=$BUILD_DIR/remote.txt
 if [ -f "$REMOTELIST" ]; then
     echo "Found remote.txt, cloning remote git repo to ~/.vmodules" | arrow
     while read -ra arr; do
-      echo "Cloning ${arr[0]} into ${arr[1]}/${arr[2]}" | indent | arrow
+      echo "Cloning ${arr[0]} into ~/${arr[1]}/${arr[2]}" | indent | arrow
       git clone ${arr[0]} ~/${arr[1]}/${arr[2]}
       echo "Symlink ~/${arr[1]} ~/.vmodules/"
       ln -s ~/${arr[1]} ~/.vmodules/

--- a/bin/compile
+++ b/bin/compile
@@ -37,6 +37,7 @@ PKGLIST=$BUILD_DIR/vpm.txt
 if [ -f "$PKGLIST" ]; then
     echo "Found vpm.txt, installing VPM packages" | arrow
     while read p; do
+      echo "test" | arrow
       echo "Installing $p" | indent | arrow
       $V_DIR/v install $p
     done < $PKGLIST

--- a/bin/compile
+++ b/bin/compile
@@ -50,9 +50,8 @@ if [ -f "$REMOTELIST" ]; then
     echo "Found remote.txt, cloning remote git repo to ~/.vmodules" | arrow
     while read -ra arr; do
       echo "Cloning ${arr[0]} into ${arr[1]}/${arr[2]}" | indent | arrow
-      git clone ${arr[0]} ~/${arr[2]}
-      mkdir ~/.vmodules/${arr[1]}
-      ln -s ~/${arr[2] ~/.vmodules/${arr[1]}
+      git clone ${arr[0]} ~/${arr[1]}/${arr[2]}
+      ln -s ~/${arr[1]} ~/.vmodules/
     done < $REMOTELIST
 else
     echo "remote.txt not found - do not install any thirdparty module from a remote repo." | arrow


### PR DESCRIPTION
The current .vmodules look like this:
```
~/.vmodules/module_name
~/.vmodules/module_name_too
```

However, this does not allow you to import the following:
```v
import zztkm.vdotenv
```

So I would like to change the path structure to the following:
```
~/.vmodules/repo_author_name/module_name
~/.vmodules/repo_author_name/module_name_too
```

This pull request is designed to achieve the above.

Please confirm.

Thank you.